### PR TITLE
1.1.1 release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # simple-rest
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/se.alipsa/simple-rest/badge.svg)](https://maven-badges.herokuapp.com/maven-central/se.alipsa/simple-rest)
+[![Maven Central](https://maven-badges.sml.io/maven-central/se.alipsa/simple-rest/badge.svg)](https://maven-badges.sml.io/maven-central/se.alipsa/simple-rest)
 [![javadoc](https://javadoc.io/badge2/se.alipsa/simple-rest/javadoc.svg)](https://javadoc.io/doc/se.alipsa/simple-rest)
 
 Simple, modular Rest library for java 17+

--- a/src/main/java/se/alipsa/simplerest/CommonHeaders.java
+++ b/src/main/java/se/alipsa/simplerest/CommonHeaders.java
@@ -1,5 +1,6 @@
 package se.alipsa.simplerest;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 
@@ -26,7 +27,8 @@ public class CommonHeaders {
    * @return a value used for the authorization header including the base 64 encoded string containing the username and password
    */
   public static String basicAuth(String username, String password) {
-    return "Basic " + Base64.getEncoder().encodeToString((username + ":" + password).getBytes());
+    return "Basic " + Base64.getEncoder()
+        .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
   }
 
   /**

--- a/src/main/java/se/alipsa/simplerest/Response.java
+++ b/src/main/java/se/alipsa/simplerest/Response.java
@@ -136,7 +136,19 @@ public class Response {
    * @return the value of the header with the name mathing the param
    */
   public String getHeader(String headerName) {
+    if (headers == null) {
+      return null;
+    }
     List<String> values = headers.get(headerName);
+    if (values == null) {
+      for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+        String key = entry.getKey();
+        if (key != null && key.equalsIgnoreCase(headerName)) {
+          values = entry.getValue();
+          break;
+        }
+      }
+    }
     if (values == null || values.isEmpty()) {
       return null;
     }
@@ -153,13 +165,12 @@ public class Response {
     if (! (o instanceof Response other)) {
       return false;
     }
-    return getResponseCode() == other.getResponseCode() && String.valueOf(getPayload()).equals(other.getPayload());
+    return getResponseCode() == other.getResponseCode()
+        && Objects.equals(getPayload(), other.getPayload());
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hashCode(getPayload());
-    result = 31 * result + getResponseCode();
-    return result;
+    return Objects.hash(getPayload(), getResponseCode());
   }
 }

--- a/src/main/java/se/alipsa/simplerest/UrlParameters.java
+++ b/src/main/java/se/alipsa/simplerest/UrlParameters.java
@@ -23,6 +23,9 @@ public class UrlParameters {
     if (params.length == 0) {
       return "";
     }
+    if (params.length % 2 != 0) {
+      throw new IllegalArgumentException("Parameters must be supplied as key/value pairs");
+    }
     String up = "?";
     int i = 0;
     for (String param : params) {

--- a/src/test/java/test/alipsa/simplerest/ResponseTest.java
+++ b/src/test/java/test/alipsa/simplerest/ResponseTest.java
@@ -1,0 +1,33 @@
+package test.alipsa.simplerest;
+
+import org.junit.jupiter.api.Test;
+import se.alipsa.simplerest.Response;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class ResponseTest {
+
+  @Test
+  public void testNullPayloadEquals() {
+    Response nullPayload = new Response(null, 200, Map.of());
+    Response stringNullPayload = new Response("null", 200, Map.of());
+    assertNotEquals(nullPayload, stringNullPayload);
+  }
+
+  @Test
+  public void testHeaderLookupCaseInsensitive() {
+    Response response = new Response("", 200, Map.of("content-type", List.of("application/json")));
+    assertEquals("application/json", response.getHeader("Content-Type"));
+  }
+
+  @Test
+  public void testHeaderLookupNullMap() {
+    Response response = new Response();
+    assertNull(response.getHeader("Content-Type"));
+  }
+}

--- a/src/test/java/test/alipsa/simplerest/UrlParametersTest.java
+++ b/src/test/java/test/alipsa/simplerest/UrlParametersTest.java
@@ -4,11 +4,17 @@ import org.junit.jupiter.api.Test;
 import se.alipsa.simplerest.UrlParameters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UrlParametersTest {
 
   @Test
   public void testUrlParams() {
     assertEquals("?foo=123&bar=898", UrlParameters.parameters("foo", "123", "bar", "898"));
+  }
+
+  @Test
+  public void testOddParamCount() {
+    assertThrows(IllegalArgumentException.class, () -> UrlParameters.parameters("foo", "123", "bar"));
   }
 }


### PR DESCRIPTION
- Fixed connection/body handling and UTF‑8 usage across request/response flows, and ensured error bodies are read when available while preserving existing GET error behavior.
- Made basic auth encoding deterministic (UTF‑8).
- Corrected Response.equals/hashCode and made header lookup null‑safe and case‑insensitive.
- Added parameter count validation for URL params and tests for the new behaviors.